### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ A UI console for the Google Cloud Platform PubSub emulator.
 ## Getting started
 
 ```shell script
-docker run -p 8680:8080 --env PUBSUB_EMULATOR_HOST=<emulator-host>:<emulator-port> --env GCP_PROJECT_IDS=<comma-separated-project-ids> gcp-pubsub-emulator-ui:latest
+docker run --rm -p 8680:8680 --env PUBSUB_EMULATOR_HOST=<emulator-host>:<emulator-port> --env GCP_PROJECT_IDS=<comma-separated-project-ids> echocode/gcp-pubsub-emulator-ui:latest
 ```
 
 The UI runs on [http://localhost:8680](localhost:8680) by default.
@@ -18,7 +18,7 @@ The UI runs on [http://localhost:8680](localhost:8680) by default.
 ### Running by pointing at local emulator
 
 ```shell script
-docker run -p 8680:8080 --env PUBSUB_EMULATOR_HOST=host.docker.internal:8681 --env GCP_PROJECT_IDS=company-dev,company-staging gcp-pubsub-emulator-ui:latest
+docker run --rm -p 8680:8680 --env PUBSUB_EMULATOR_HOST=host.docker.internal:8681 --env GCP_PROJECT_IDS=company-dev,company-staging echocode/gcp-pubsub-emulator-ui:latest
 ```
 
 ### Running in an existing docker-compose.yaml


### PR DESCRIPTION
Fixed wrong port forwarding rule as by default app listens on 8680 and not 8080

Also added docker hub repo prefix as without it I got errors:
```
Unable to find image 'gcp-pubsub-emulator-ui:latest' locally
docker: Error response from daemon: pull access denied for gcp-pubsub-emulator-ui, repository does not exist or may require 'docker login': denied: requested access to the resource is denied.
```